### PR TITLE
Fix iPad StateGantt width to 100%. Closes #37

### DIFF
--- a/src/components/style.scss
+++ b/src/components/style.scss
@@ -66,6 +66,7 @@
   			width: 100%;
   		}
   		@include mobile {
+        width: 100%;
   			border-spacing: 4px;
   		}
   		table-layout: fixed;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/113293/93037742-f8e97c80-f5f7-11ea-8d71-bb8ea9fc949b.png)
