### PR TITLE
Use officialInfoEarlyVotingCombined

### DIFF
--- a/src/components/state-early-voting-countdown.js
+++ b/src/components/state-early-voting-countdown.js
@@ -31,7 +31,7 @@ const messageForCountdown = (fullStateName, numDaysToStart, startDateString) => 
 const StateEarlyVotingCountdown = (data) => {
   data = data.data
 
-  var endDateString = data.year2020EarlyVotingEnds;
+  var endDateString = data.year2020EarlyVotingEndsCombined;
   var startDateString = data.year2020EarlyVotingStartsCombined;
   var startDate = dateFromString(startDateString);
   var daysLeft = numDaysToStart(startDate);

--- a/src/components/state-early-voting-countdown.js
+++ b/src/components/state-early-voting-countdown.js
@@ -32,7 +32,7 @@ const StateEarlyVotingCountdown = (data) => {
   data = data.data
 
   var endDateString = data.year2020EarlyVotingEnds;
-  var startDateString = data.year2020EarlyVotingStarts;
+  var startDateString = data.year2020EarlyVotingStartsCombined;
   var startDate = dateFromString(startDateString);
   var daysLeft = numDaysToStart(startDate);
 

--- a/src/components/state/header.js
+++ b/src/components/state/header.js
@@ -35,7 +35,7 @@ const StateCanEarlyVote = ({ stateData }) => (
     </h1>
     <p className="subtitle has-text-white is-size-3-desktop is-size-4-mobile">
       Get the official info here:&nbsp;
-      <Link to={stateData.officialInfoEarlyVoting} target="_blank" class="hilight">
+      <Link to={stateData.officialInfoEarlyVotingCombined} target="_blank" class="hilight">
         {stateData.fullStateName} Early Voting Info
       </Link>
     </p>

--- a/src/templates/state-page.js
+++ b/src/templates/state-page.js
@@ -185,7 +185,7 @@ export const query = graphql`
       earlyVotingStarts
       earlyVotingEnds
       year2020EarlyVotingStartsCombined
-      year2020EarlyVotingEnds
+      year2020EarlyVotingEndsCombined
       earlyVotingNotesCombined
       officialInfoEarlyVotingCombined
       year2020OfficialElectionCalendar

--- a/src/templates/state-page.js
+++ b/src/templates/state-page.js
@@ -62,7 +62,7 @@ export default function StatePage({ data }) {
                           if (canEarlyVote(stateData)) {
                             return (
                               <React.Fragment>
-                                <Link to={stateData.officialInfoEarlyVoting} target="_blank"
+                                <Link to={stateData.officialInfoEarlyVotingCombined} target="_blank"
                                   class="button is-link">
                                   {stateData.fullStateName} Early Voting Info
                                 </Link>
@@ -101,7 +101,7 @@ export default function StatePage({ data }) {
                       if (canEarlyVote(stateData)) {
                         return (
                           <div class="subtitle is-5">
-                            Here's the <Link to={stateData.officialInfoEarlyVoting} target="_blank">
+                            Here's the <Link to={stateData.officialInfoEarlyVotingCombined} target="_blank">
                               official early voting info for {stateData.fullStateName}.
                                            </Link>
                           </div>
@@ -186,9 +186,8 @@ export const query = graphql`
       earlyVotingEnds
       year2020EarlyVotingStarts
       year2020EarlyVotingEnds
-      earlyVotingNotes
       earlyVotingNotesCombined
-      officialInfoEarlyVoting
+      officialInfoEarlyVotingCombined
       year2020OfficialElectionCalendar
       officialInfoVoterId
       year2020VbmRequestDeadlineByMail

--- a/src/templates/state-page.js
+++ b/src/templates/state-page.js
@@ -184,7 +184,7 @@ export const query = graphql`
       fullStateName
       earlyVotingStarts
       earlyVotingEnds
-      year2020EarlyVotingStarts
+      year2020EarlyVotingStartsCombined
       year2020EarlyVotingEnds
       earlyVotingNotesCombined
       officialInfoEarlyVotingCombined

--- a/src/templates/va-api-data-fields.txt
+++ b/src/templates/va-api-data-fields.txt
@@ -29,7 +29,6 @@ year2020OfficialElectionCalendar
 officialInfoEarlyVoting
 officialInfoVoterId
 year2020EarlyVotingStarts
-year2020EarlyVotingStartsCombined
 sdrNotes
 registrationNvrfSubmissionAddress
 pollsOpen

--- a/src/templates/va-api-data-fields.txt
+++ b/src/templates/va-api-data-fields.txt
@@ -29,6 +29,7 @@ year2020OfficialElectionCalendar
 officialInfoEarlyVoting
 officialInfoVoterId
 year2020EarlyVotingStarts
+year2020EarlyVotingStartsCombined
 sdrNotes
 registrationNvrfSubmissionAddress
 pollsOpen


### PR DESCRIPTION
This fixes issues where the official info link is missing on certain state pages. Examples include Michigan and Virginia.