### PR TITLE
Use the early-voting-data sheet on the homepage

### DIFF
--- a/src/components/state-gantt.js
+++ b/src/components/state-gantt.js
@@ -16,7 +16,7 @@ let quips = {
 let usedQuips = []
 
 function layoutStateRows(stateData) {
-  const startDate = parseDate(stateData.earlyVotingStartDate)
+  const startDate = parseDate(stateData.year2020EarlyVotingStartsCombined)
   const chartStartDate = parseDate('2020-09-17')
   const days = dateDiffInDays(startDate, electionDate)
   stateData.daysToStart = dateDiffInDays(chartStartDate, startDate)
@@ -43,12 +43,12 @@ const StateGantt = () => (
   <StaticQuery
   query={graphql`
     {
-      allGoogleSheetSiteDatesRow {
+      allGoogleSheetEarlyVotingDataRow {
         nodes {
-          state
+          year2020EarlyVotingStartsCombined
+          year2020EarlyVotingEndsCombined
+          fullStateName
           daysToVote
-          earlyVotingStartDate
-          earlyVotingEndDate
         }
       }
     }
@@ -65,7 +65,7 @@ const StateGantt = () => (
             <td class="bars" colspan="46">
               <table class="is-fullwidth is-fullwidth-mobile">
                 {
-                  data.allGoogleSheetSiteDatesRow.nodes.map(layoutStateRows)
+                  data.allGoogleSheetEarlyVotingDataRow.nodes.map(layoutStateRows)
                 }
               </table>
             </td>

--- a/src/components/state-row.js
+++ b/src/components/state-row.js
@@ -16,10 +16,10 @@ const StateRow = (data) => {
     return null
   }
 
-  var statePage = statePageUri(data.state);
+  var statePage = statePageUri(data.fullStateName);
 
-  var endDate = parseDate(data.earlyVotingEndDate)
-  var startDate = parseDate(data.earlyVotingStartDate)
+  var endDate = parseDate(data.year2020EarlyVotingEndsCombined)
+  var startDate = parseDate(data.year2020EarlyVotingStartsCombined)
 
   data.shortStartDate = (startDate.month() + 1) + '/' + startDate.date()
 
@@ -36,7 +36,7 @@ const StateRow = (data) => {
   if (data.daysToVote < 3) {
     return (
       <tr>
-        <th><Link to={statePage}>{data.state}</Link></th>
+        <th><Link to={statePage}>{data.fullStateName}</Link></th>
         <td colspan={data.daysToStart} class="bar-spacer">{data.shortStartDate}</td>
         <td colspan={daysToVote} class="bar">
           <Link to={statePage}>
@@ -51,7 +51,7 @@ const StateRow = (data) => {
 
   return (
     <tr>
-      <th><Link to={statePage}>{data.state}</Link></th>
+      <th><Link to={statePage}>{data.fullStateName}</Link></th>
       <td colspan={data.daysToStart} class="bar-spacer">
         <span class={(
           () => {


### PR DESCRIPTION
We were using a sheet called site-dates on the homepage previously,
but it was missing the manually updated start dates that are on the
state pages. This should fix that issue by standardizing us on the
early-voting-data sheet tab.