### PR TITLE
Fix slug, add short state name so buttons don't break

### DIFF
--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -1,12 +1,22 @@
 const slugifyState = (stateName) => {
-    return stateName.toLowerCase().replace(' ', '-');
+    return stateName.toLowerCase().replaceAll(' ', '-');
 }
 
 const statePageUri = (stateName) => {
     return '/' + slugifyState(stateName);
 }
 
+const shortStateName = (fullStateName) => {
+  switch (fullStateName) {
+    case 'District of Columbia':
+      return 'Washington DC';
+    default:
+      return fullStateName;
+  }
+}
+
 module.exports = {
     slugifyState: slugifyState,
     statePageUri: statePageUri,
+    shortStateName: shortStateName,
 }

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -7,7 +7,7 @@ const statePageUri = (stateName) => {
 }
 
 const shortStateName = (fullStateName) => {
-  switch (fullStateName) {
+  switch (fullStateName.trim()) {
     case 'District of Columbia':
       return 'Washington DC';
     default:

--- a/src/templates/state-page.js
+++ b/src/templates/state-page.js
@@ -1,6 +1,7 @@
 import React from "react"
 import '../components/style.scss';
 import { graphql, Link } from 'gatsby';
+import { shortStateName } from '../lib/common';
 
 import Helmet from '../components/helmet';
 import SiteDescription from '../components/site-description';
@@ -68,7 +69,7 @@ export default function StatePage({ data }) {
                               <React.Fragment>
                                 <Link to={stateData.officialInfoEarlyVotingCombined} target="_blank"
                                   class="button is-link">
-                                  {stateData.fullStateName} Early Voting Info
+                                  {shortStateName(stateData.fullStateName)} Early Voting Info
                                 </Link>
                               </React.Fragment>
                             );
@@ -79,13 +80,13 @@ export default function StatePage({ data }) {
                     <div className="column is-narrow">
                       <Link to={stateData.sosElectionWebsite} target="_blank"
                         class="button">
-                        {stateData.fullStateName} Election Website
+                        {shortStateName(stateData.fullStateName)} Election Website
                       </Link>
                     </div>
                     <div className="column is-narrow">
                       <Link to={stateData.year2020OfficialElectionCalendar} target="_blank"
                         class="button">
-                        {stateData.fullStateName} Election Calendar
+                        {shortStateName(stateData.fullStateName)} Election Calendar
                       </Link>
                     </div>
                   </div>


### PR DESCRIPTION
Fixes the slug for District of Columbia.

Also, on the DC page the text for the buttons is too long for the full name. In order to prevent overflow, I am printing "Washington DC" in there instead.